### PR TITLE
docs: fix typos

### DIFF
--- a/development.mdx
+++ b/development.mdx
@@ -22,7 +22,7 @@ yarn global add mintlify
 
 </CodeGroup>
 
-Step 2. Go to the docs are located (where you can find `mint.json`) and run the following command:
+Step 2. Go to where the docs are located (where you can find `mint.json`) and run the following command:
 
 ```bash
 mintlify dev

--- a/governor.mdx
+++ b/governor.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agora Governor
-description: "A powerful and flexbile goverance system built on open standards."
+description: "A powerful and flexible governance system built on open standards."
 ---
 
 <img
@@ -17,13 +17,13 @@ The community governs the protocol using a token. This token typically takes the
 
 If the proposal passes, the transactions attached to the proposal are executed. If the proposal does not pass, no change is made. This process is repeated over time, allowing the protocol to evolve and adapt to changing circumstances and requirements through the collective wisdom of the community.
 
-For example, let's say that you have decentralized lending protocol and one of the parameters is your annual interest rate. When you deploy the protocol you set it to 3.2%. As the macroeconomic conditions of the world change, you might want to change that number to bring it up or down. Community members that have the ability to propose might create a proposal and attach a transaction such as:
+For example, let's say that you have a decentralized lending protocol and one of the parameters is your annual interest rate. When you deploy the protocol you set it to 3.2%. As the macroeconomic conditions of the world change, you might want to change that number to bring it up or down. Community members that have the ability to propose might create a proposal and attach a transaction such as:
 
 ```
 setInterestRate(0.033)
 ```
 
-If the proposal passes, the Etherium Virtual Machine (EVM) will execute this transaction and the function setInterestRate will be set to 0.033 or 3.3%. If the proposal fails to pass it will stay at 3.2%. Other members of the community can then come and propose other values. This process will continue until the right number is decided upon by the community, or they might find that there is no number everyone can agree on and it stays put at 3.2%.
+If the proposal passes, the Ethereum Virtual Machine (EVM) will execute this transaction and the function setInterestRate will be set to 0.033 or 3.3%. If the proposal fails to pass it will stay at 3.2%. Other members of the community can then come and propose other values. This process will continue until the right number is decided upon by the community, or they might find that there is no number everyone can agree on and it stays put at 3.2%.
 
 Now imagine this process repeating for a complex protocol with dozens of parameters.
 

--- a/snippets/snippet-intro.mdx
+++ b/snippets/snippet-intro.mdx
@@ -1,4 +1,4 @@
 One of the core principles of software development is DRY (Don't Repeat
-Yourself). This is a principle that apply to documentation as
+Yourself). This is a principle that applies to documentation as
 well. If you find yourself repeating the same content in multiple places, you
 should consider creating a custom snippet to keep your content in sync.


### PR DESCRIPTION
# Rationale for this change

I checked all the ‘md’, 'mdx' files within the repository.

As a result, I found a few typos, and I expect the documentation to be clean if I fix them.

Fixing typos makes the documentation more readable and clear.

There were also some awkward wording and punctuation, but I didn't fix those because they don't detract too much from the meaning of the original documentation and don't cause any problems in understanding the documentation.

# What changes are included in this PR?

Correct typos in the modified files. Each commit explains that which typos are corrected and reason.
