### PR TITLE
Remove broken S3 image

### DIFF
--- a/agora-governor.mdx
+++ b/agora-governor.mdx
@@ -15,8 +15,6 @@ Agora stands on the shoulders of OpenZeppelin’s battle-tested contracts. By bu
 
 Agora’s enhancements—like partial delegation, advanced proposal configuration, and expanded module support—provide a cutting-edge governance platform built with proven foundations.
 
-![CleanShot 2024-12-11 at 11.27.22@2x.png](https://prod-files-secure.s3.us-west-2.amazonaws.com/c82d05ff-47d7-48d8-bcf8-39ac135426b8/ba98d3a6-9b51-432c-871a-ce48e55f3590/CleanShot_2024-12-11_at_11.27.222x.png)
-
 Think of Agora as edge OpenZeppelin. We are meeting our customers on the frontlines of governance and are committed to Open Source and giving back to the OpenZeppelin community. This is why we are a proud member of the [Governance Working group led by OpenZeppelin](https://blog.openzeppelin.com/announcing-a-new-working-group-for-openzeppelin-governor) and includes other great founding members such as Tally and ScopeLift.
 
 ### The Agora Governor Contracts


### PR DESCRIPTION
It was showing up like this:

<img width="557" alt="image" src="https://github.com/user-attachments/assets/b4f6a2c5-eb76-4ba8-8017-a62911b3da88" />

The link is either wrong or not-public.